### PR TITLE
Ajout du support pour les ColorBulbs

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -164,6 +164,7 @@ HILO_LIST_ATTRIBUTES: Final = [
 
 HILO_DEVICE_TYPES: Final = {
     "ChargingPoint": "Sensor",
+    "ColorBulb": "Light",
     "Gateway": "Sensor",
     "IndoorWeatherStation": "Sensor",
     "LightDimmer": "Light",
@@ -189,11 +190,13 @@ HILO_UNIT_CONVERSION: Final = {
 HILO_READING_TYPES: Final = {
     "BatteryPercent": "Percentage",
     "Co2": "PPM",
+    "ColorTemperature": "Integer",
     "CurrentTemperature": "Celcius",
     "Disconnected": "null",
     "DrmsState": "OnOff",
     "firmwareVersion": "null",
     "Heating": "Percentage",
+    "Hue": "Integer",
     "Humidity": "Percentage",
     "Intensity": "Percentage",
     "MaxTempSetpoint": "Celcius",
@@ -203,6 +206,7 @@ HILO_READING_TYPES: Final = {
     "OnOff": "OnOff",
     "Power": "Watt",
     "Pressure": "Mbar",
+    "Saturation": "Integer",
     "Status": "OnOff",
     "TargetTemperature": "Celcius",
     "WifiStatus": "Integer",

--- a/pyhilo/device/light.py
+++ b/pyhilo/device/light.py
@@ -19,3 +19,19 @@ class Light(HiloDevice):
     @property
     def state(self) -> str:
         return "on" if self.get_value("is_on") else "off"
+
+    @property
+    def hue(self) -> int:
+        return self.get_value("hue") or 0
+
+    @property
+    def intensity(self) -> int:
+        return self.get_value("intensity") * 255 or 0
+
+    @property
+    def saturation(self) -> int:
+        return self.get_value("saturation") or 0
+
+    @property
+    def color_temperature(self) -> int:
+        return self.get_value("ColorTemperature") or 0


### PR DESCRIPTION
Ajoute les attributs et les constants nécéssaire pour supporter les lumière RGBW. 

Testé avec une ampoule intelligente de couleur Sylvania A19 Smart+
Modèle : 74933
Je n'ai pas pu testé si le support pour les ampoules non RGB est correcte puisque je n'en possède pas.