### PR TITLE
Ajout de "+"

### DIFF
--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -165,7 +165,7 @@ class API:
         api._username = username
         api._state_yaml = state_yaml
         api.state = get_state(state_yaml)
-        password = parse.quote(password, safe="!@#$%^&*()")
+        password = parse.quote(password, safe="!@#$%^&*()+")
         auth_body = api.auth_body(
             AUTH_TYPE_PASSWORD, username=username, password=password
         )


### PR DESCRIPTION
Ajout de "+" comme caractère accepté de mot de passe pour les gens utilisant des mots de passes complexe. Testé en local en changeant mon mot de passe pour y mettre un + et ça fonctionne.

Fix pour dvd-dev/hilo#313 et possiblement dvd-dev/hilo#306 et dvd-dev/hilo#309