### PR TITLE
Ajout de caractères spéciaux

### DIFF
--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -165,7 +165,7 @@ class API:
         api._username = username
         api._state_yaml = state_yaml
         api.state = get_state(state_yaml)
-        password = parse.quote(password, safe="!@#$%^&*()+")
+        password = parse.quote(password, safe="!@#$%^?&*()_+")
         auth_body = api.auth_body(
             AUTH_TYPE_PASSWORD, username=username, password=password
         )


### PR DESCRIPTION
Dans les caractères parsé par urllib, ça va éviter des auth_errors pour les gens qui ont des caractères spéciaux dans le mot de passe voir dvd-dev/hilo#331