### PR TITLE
Issue #310: Fix value reverts back to original value in the UI

### DIFF
--- a/pyhilo/device/__init__.py
+++ b/pyhilo/device/__init__.py
@@ -116,6 +116,19 @@ class HiloDevice:
     ) -> None:
         if attribute in self.settable_attributes:
             await self._api._set_device_attribute(self, attribute, value)
+            # Update internal state after sending request to API, assuming it will
+            # succeed and we will get a reading back form signalR. This avoids ui flickering.
+            self.update_readings(
+                DeviceReading(
+                    **{
+                        "deviceId": self.id,
+                        "locationId": self.location_id,
+                        "timeStampUTC": datetime.utcnow().isoformat(),
+                        "value": value,
+                        "device_attribute": attribute,
+                    }  # type: ignore
+                )
+            )
         else:
             LOG.warning(f"{self._tag} Invalid attribute {attribute} for device")
 


### PR DESCRIPTION
https://github.com/dvd-dev/hilo/issues/310
Set internal state to assumed value (that one just set) to avoid a revert-to-original in the UI. We end up getting the actual value from SignalR later (0 to 10s later).