### PR TITLE
Add missing device type WhiteBulb

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -182,6 +182,7 @@ HILO_LIST_ATTRIBUTES: Final = [
 HILO_DEVICE_TYPES: Final = {
     "ChargingPoint": "Sensor",
     "ColorBulb": "Light",
+    "WhiteBulb": "Light",
     "Gateway": "Sensor",
     "IndoorWeatherStation": "Sensor",
     "LightDimmer": "Light",


### PR DESCRIPTION
Adds supports for bulbs that report as White Bulb, such as Sylvana Smart+.