### PR TITLE
Ajout UNMONITORED_DEVICES pour utilitisation dans hilo/sensor.py

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -263,3 +263,8 @@ JASCO_OUTLETS: Final = [
     "43100",
     "45853",
 ]
+
+UNMONITORED_DEVICES: Final = [
+    "43076",
+    "43100",
+]

--- a/pyhilo/device/__init__.py
+++ b/pyhilo/device/__init__.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Union, cast
 
+from homeassistant.const import STATE_UNKNOWN
+
 from pyhilo.const import (
     HILO_DEVICE_ATTRIBUTES,
     HILO_LIST_ATTRIBUTES,
@@ -150,7 +152,7 @@ class HiloDevice:
         return next((True for k in self.supported_attributes if k.attr == attr), False)
 
     def get_value(
-        self, attribute: str, default: Union[str, int, float, None] = None
+        self, attribute: str, default: Union[str, int, float, None] = STATE_UNKNOWN
     ) -> Any:
         attr = self.get_attribute(attribute)
         return attr.value if attr else default


### PR DESCRIPTION
Désolé, j'aurais du l'ajouté hier en même temps que l'autre commit. Au début je pensais l'ajouter dans hilo/const.py, mais finalement puisque c'est une liste de devices je trouvais que ça faisait peut-être plus de sens de le mettre ici pour les regroupés. Je ne l'utiliserai pas dans python-hilo. Donc dites moi si vous trouvez que ça serait mieux dans hilo.
Merci!