### PR TITLE
Ajout UNMONITORED_DEVICES pour utilitisation dans hilo/sensor.py

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -263,3 +263,8 @@ JASCO_OUTLETS: Final = [
     "43100",
     "45853",
 ]
+
+UNMONITORED_DEVICES: Final = [
+    "43076",
+    "43100",
+]


### PR DESCRIPTION
Désolé, j'aurais du l'ajouté hier en même temps que l'autre commit. Au début je pensais l'ajouter dans hilo/const.py, mais finalement puisque c'est une liste de devices je trouvais que ça faisait peut-être plus de sens de le mettre ici pour les regroupés. Je ne l'utiliserai pas dans python-hilo. Donc dites moi si vous trouvez que ça serait mieux dans hilo.
Merci!