### PR TITLE
Changement de la valeur par défault du get_value de None à 'unknown'

### DIFF
--- a/pyhilo/device/__init__.py
+++ b/pyhilo/device/__init__.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Union, cast
 
+from homeassistant.const import STATE_UNKNOWN
+
 from pyhilo.const import (
     HILO_DEVICE_ATTRIBUTES,
     HILO_LIST_ATTRIBUTES,
@@ -150,7 +152,7 @@ class HiloDevice:
         return next((True for k in self.supported_attributes if k.attr == attr), False)
 
     def get_value(
-        self, attribute: str, default: Union[str, int, float, None] = None
+        self, attribute: str, default: Union[str, int, float, None] = STATE_UNKNOWN
     ) -> Any:
         attr = self.get_attribute(attribute)
         return attr.value if attr else default


### PR DESCRIPTION
Unknown est un état que HA comprend, c'est la valeur qui est donné aux entité lorsque les données ne sont pas disponible.

Pour l'instant tous les get_value dans Hilo sont spéficiés avec une valeur de 0 pour la valeur par défaut. Donc pour l'instant ce changement n'aura aucun impact. J'ai fait des tests en changeant l'intégration, je vais mettre à jour prochainement.