### PR TITLE
Fix pour les problèmes de min/max de thermostats

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 David Vallee Delisle
+Copyright (c) 2020-2024 David Vallee Delisle
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pyhilo/device/climate.py
+++ b/pyhilo/device/climate.py
@@ -22,11 +22,19 @@ class Climate(HiloDevice):
 
     @property
     def max_temp(self) -> float:
-        return cast(float, self.get_value("max_temp_setpoint", 30))
+        value = self.get_value("max_temp_setpoint", 30)
+
+        if value is None or value == 0:
+            return 36.0
+        return float(value)
 
     @property
     def min_temp(self) -> float:
-        return cast(float, self.get_value("min_temp_setpoint", 5))
+        value = self.get_value("min_temp_setpoint", 5)
+
+        if value is None or value == 0:
+            return 5.0
+        return float(value)
 
     @property
     def hvac_action(self) -> str:

--- a/pyhilo/device/climate.py
+++ b/pyhilo/device/climate.py
@@ -22,11 +22,11 @@ class Climate(HiloDevice):
 
     @property
     def max_temp(self) -> float:
-        return cast(float, self.get_value("max_temp_setpoint", 0))
+        return cast(float, self.get_value("max_temp_setpoint", 30))
 
     @property
     def min_temp(self) -> float:
-        return cast(float, self.get_value("min_temp_setpoint", 0))
+        return cast(float, self.get_value("min_temp_setpoint", 5))
 
     @property
     def hvac_action(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ exclude = ".venv/.*"
 
 [tool.poetry]
 name = "python-hilo"
-version = "2024.6.1"
+version = "2024.10.1"
 description = "A Python3, async interface to the Hilo API"
 readme = "README.md"
 authors = ["David Vallee Delisle <me@dvd.dev>"]


### PR DESCRIPTION
Problème soulevé dans dvd-dev/hilo#466. Hilo nous a poussé des valeurs nulles par erreur et on dirait que ça reste collé.

Fait une petite logique pour ramasser la valeur des min/max lorsqu'elles existent, sinon si elles sont vides ou = 0 je hard code ça à 5-36 pour inclure les thermostats de plancher.

C'est pas super chic, mais ça devrait nous sortir du trouble.