### PR TITLE
Fix attempt pour issue 457

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
           - types-aiofiles==23.2.0
  
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v5.0.0
     hooks:
       - id: check-json
       - id: no-commit-to-branch

--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -399,6 +399,7 @@ class API:
             "available_transports": transport_dict,
             "full_ws_url": self.full_ws_url,
         }
+        LOG.debug("Calling set_state")
         await set_state(self._state_yaml, "websocket", websocket_dict)
 
     async def fb_install(self, fb_id: str) -> None:
@@ -424,6 +425,7 @@ class API:
             raise RequestError(err) from err
         LOG.debug(f"FB Install data: {resp}")
         auth_token = resp.get("authToken", {})
+        LOG.debug("Calling set_state")
         await set_state(
             self._state_yaml,
             "firebase",
@@ -465,6 +467,7 @@ class API:
             LOG.error(f"Android registration error: {msg}")
             raise RequestError
         token = msg.split("=")[-1]
+        LOG.debug("Calling set_state")
         await set_state(
             self._state_yaml,
             "android",

--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -367,6 +367,7 @@ class API:
         resp = await self.async_request("post", url)
         ws_url = resp.get("url")
         ws_token = resp.get("accessToken")
+        LOG.debug("Calling set_state")
         await set_state(
             self._state_yaml,
             "websocket",

--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -8,7 +8,7 @@ import homeassistant.core
 LOG: Final = logging.getLogger(__package__)
 DEFAULT_STATE_FILE: Final = "hilo_state.yaml"
 REQUEST_RETRY: Final = 9
-PYHILO_VERSION: Final = "2024.06.01"
+PYHILO_VERSION: Final = "2024.10.02"
 # TODO: Find a way to keep previous line in sync with pyproject.toml automatically
 
 CONTENT_TYPE_FORM: Final = "application/x-www-form-urlencoded"

--- a/pyhilo/util/state.py
+++ b/pyhilo/util/state.py
@@ -3,10 +3,12 @@ from os.path import isfile
 from typing import Any, Optional, Type, TypedDict, TypeVar, Union
 
 import aiofiles
+import asyncio
 import ruyaml as yaml
 
 from pyhilo.const import LOG
 
+lock = asyncio.Lock()
 
 class TokenDict(TypedDict):
     access: Optional[str]
@@ -103,10 +105,11 @@ async def set_state(
     :type state: ``StateDict``
     :rtype: ``StateDict``
     """
-    current_state = await get_state(state_yaml) or {}
-    merged_state: dict[str, Any] = {key: {**current_state.get(key, {}), **state}}  # type: ignore
-    new_state: dict[str, Any] = {**current_state, **merged_state}
-    async with aiofiles.open(state_yaml, mode="w") as yaml_file:
-        LOG.debug("Saving state to yaml file")
-        content = yaml.dump(new_state)
-        await yaml_file.write(content)
+    async with lock: #note ic-dev21: on lock le fichier pour être sûr de finir la job
+        current_state = await get_state(state_yaml) or {}
+        merged_state: dict[str, Any] = {key: {**current_state.get(key, {}), **state}}  # type: ignore
+        new_state: dict[str, Any] = {**current_state, **merged_state}
+        async with aiofiles.open(state_yaml, mode="w") as yaml_file:
+            LOG.debug("Saving state to yaml file")
+            content = yaml.dump(new_state)
+            await yaml_file.write(content)

--- a/pyhilo/util/state.py
+++ b/pyhilo/util/state.py
@@ -1,14 +1,15 @@
+import asyncio
 from datetime import datetime
 from os.path import isfile
 from typing import Any, Optional, Type, TypedDict, TypeVar, Union
 
 import aiofiles
-import asyncio
 import ruyaml as yaml
 
 from pyhilo.const import LOG
 
 lock = asyncio.Lock()
+
 
 class TokenDict(TypedDict):
     access: Optional[str]
@@ -105,7 +106,7 @@ async def set_state(
     :type state: ``StateDict``
     :rtype: ``StateDict``
     """
-    async with lock: #note ic-dev21: on lock le fichier pour être sûr de finir la job
+    async with lock:  # note ic-dev21: on lock le fichier pour être sûr de finir la job
         current_state = await get_state(state_yaml) or {}
         merged_state: dict[str, Any] = {key: {**current_state.get(key, {}), **state}}  # type: ignore
         new_state: dict[str, Any] = {**current_state, **merged_state}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ exclude = ".venv/.*"
 
 [tool.poetry]
 name = "python-hilo"
-version = "2024.10.1"
+version = "2024.10.2"
 description = "A Python3, async interface to the Hilo API"
 readme = "README.md"
 authors = ["David Vallee Delisle <me@dvd.dev>"]


### PR DESCRIPTION
Ajout d'un lock au fichier hilo_state.yaml pendant l'écriture pour éviter que plus qu'un thread écrive dedans en même temps.

Pourrait possiblement régler dvd-dev/hilo#457