### PR TITLE
Keeping the right tokens for every websocket connection

### DIFF
--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -311,8 +311,9 @@ class API:
                 LOG.info(
                     "401 detected on websocket, refreshing websocket token. Old url: {self.ws_url} Old Token: {self.ws_token}"
                 )
+                LOG.info(f"401 detected on {err.request_info.url}")
                 async with self._backoff_refresh_lock_ws:
-                    (self.ws_url, self.ws_token) = await self.post_devicehub_negociate()
+                    await self.refresh_ws_token()
                     await self.get_websocket_params()
                 return
 
@@ -362,7 +363,7 @@ class API:
         LOG.debug("Websocket postinit")
         await self._get_fid()
         await self._get_device_token()
-        await self.refresh_ws_token()
+        # await self.refresh_ws_token()
         # self.websocket = WebsocketClient(self)
 
         # Initialize WebsocketManager ic-dev21
@@ -376,8 +377,9 @@ class API:
         self.websocket2 = WebsocketClient(self, self.websocket_manager.challengehub)
 
     async def refresh_ws_token(self) -> None:
-        (self.ws_url, self.ws_token) = await self.post_devicehub_negociate()
-        await self.get_websocket_params()
+        """Refresh the websocket token."""
+        await self.websocket_manager.refresh_token(self.websocket_manager.devicehub)
+        await self.websocket_manager.refresh_token(self.websocket_manager.challengehub)
 
     async def post_devicehub_negociate(self) -> tuple[str, str]:
         LOG.debug("Getting websocket url")

--- a/pyhilo/websocket.py
+++ b/pyhilo/websocket.py
@@ -424,7 +424,7 @@ class WebsocketManager:
         # ic-dev21 get token from device hub
         await self.refresh_token(self.devicehub, get_new_token=True)
         # ic-dev21 reuse it for challenge hub
-        await self.refresh_token(self.challengehub, get_new_token=False)
+        await self.refresh_token(self.challengehub, get_new_token=True)
 
     async def refresh_token(
         self, config: WebsocketConfig, get_new_token: bool = True
@@ -459,11 +459,8 @@ class WebsocketManager:
 
         resp = await self.async_request("post", url)
         ws_url = resp.get("url")
-        ws_token = (
-            resp.get("accessToken")
-            if self._shared_token is None
-            else self._shared_token
-        )
+        ws_token =   resp.get("accessToken")
+          
 
         # Save state
         state_key = (


### PR DESCRIPTION
Plus de 401 pour les ws.

J’ai été un peu brutal sur le refresh_ws de api.py , sinon ça tentait de refresh le deuxième ws avec le endpoint du premier. Je pense que faire une liste ou un dict serait peut être plus simple ensuite mais ça demande quand même un peu de refactor.

Pour ce qui bloquait, il me semble que chaque ws a besoin de son propre token, le shared_token c’est probablement ce qui bloque, j’ai donc modifié pour que les deux soit bien avec leur propre token (facile avec la conf), et je récupère bien l’url.