### PR TITLE
Fix lint error: PGH004 Use specific rule codes when using `noqa`

### DIFF
--- a/pyhilo/__init__.py
+++ b/pyhilo/__init__.py
@@ -1,3 +1,27 @@
 """Define the hilo package."""
-from pyhilo.api import API  # noqa
-from pyhilo.devices import Devices  # noqa
+from pyhilo.api import API
+from pyhilo.devices import Devices
+from pyhilo.device import HiloDevice
+from pyhilo.event import Event
+from pyhilo.exceptions import HiloError, InvalidCredentialsError, WebsocketError
+from pyhilo.oauth2 import AuthCodeWithPKCEImplementation
+from pyhilo.util import from_utc_timestamp, time_diff
+from pyhilo.websocket import WebsocketEvent
+from pyhilo.const import UNMONITORED_DEVICES
+from pyhilo.device.switch import Switch
+
+__all__ = [
+    "API",
+    "Devices",
+    "HiloDevice",
+    "Event",
+    "HiloError",
+    "InvalidCredentialsError",
+    "WebsocketError",
+    "AuthCodeWithPKCEImplementation",
+    "from_utc_timestamp",
+    "time_diff",
+    "WebsocketEvent",
+    "UNMONITORED_DEVICES",
+    "Switch",
+]


### PR DESCRIPTION
This PR is fixing some lint errors to make it easier to implement #244

This also exports __all__ the modules used by Hilo in HASS. 

https://docs.python.org/3/tutorial/modules.html#importing-from-a-package