### PR TITLE
Fix multiple linting error in climate.py

### DIFF
--- a/pyhilo/device/__init__.py
+++ b/pyhilo/device/__init__.py
@@ -32,7 +32,7 @@ def get_device_attributes() -> list[DeviceAttribute]:
 
 class HiloDevice:
     def __init__(
-        self, api: API, **kwargs: Dict[str, Union[str, int, Dict[Any, Any]]]
+        self, api: API, **kwargs: Dict[str, str | int | Dict[Any, Any]]
     ) -> None:
         self._api = api
         self.id = 0
@@ -85,7 +85,8 @@ class HiloDevice:
                     new_val.append(DeviceAttribute("Disconnected", "null"))
             elif att == "provider":
                 att = "manufacturer"
-                new_val = HILO_PROVIDERS.get(int(val), f"Unknown ({val})")  # type: ignore
+                new_val = HILO_PROVIDERS.get(
+                    int(val), f"Unknown ({val})")  # type: ignore
             else:
                 if att == "serial":
                     att = "identifier"
@@ -230,7 +231,8 @@ class DeviceReading:
         #       attr='intensity',
         #       value_type='%')
         # }
-        kwargs["timeStamp"] = from_utc_timestamp(kwargs.pop("timeStampUTC", ""))  # type: ignore
+        kwargs["timeStamp"] = from_utc_timestamp(
+            kwargs.pop("timeStampUTC", ""))  # type: ignore
         self.id = 0
         self.value: Union[int, bool, str] = 0
         self.device_id = 0
@@ -242,7 +244,8 @@ class DeviceReading:
             else ""
         )
         if not self.device_attribute:
-            LOG.warning(f"Received invalid reading for {self.device_id}: {kwargs}")
+            LOG.warning(
+                f"Received invalid reading for {self.device_id}: {kwargs}")
 
     def __repr__(self) -> str:
         return f"<Reading {self.device_attribute.attr} {self.value}{self.unit_of_measurement}>"

--- a/pyhilo/device/climate.py
+++ b/pyhilo/device/climate.py
@@ -1,6 +1,6 @@
-"""Climate object """
-
-from typing import Union, cast
+"""Climate object."""
+from __future__ import annotations
+from typing import Any, cast
 
 from pyhilo import API
 from pyhilo.const import LOG
@@ -8,20 +8,51 @@ from pyhilo.device import HiloDevice
 
 
 class Climate(HiloDevice):
-    def __init__(self, api: API, **kwargs: dict[str, Union[str, int]]):
-        super().__init__(api, **kwargs)  # type: ignore
-        LOG.debug(f"Setting up Climate device: {self.name}")
+    """
+    Represents a climate device within the Hilo ecosystem.
+
+    This class provides methods to interact with and control climate-related
+    devices such as thermostats.
+    """
+
+    def __init__(self, api: API, **kwargs: dict[str, str | int | dict[Any, Any]]) -> None:
+        """Initialize the Climate object.
+
+            Args:
+                api: The Hilo API instance.
+                **kwargs: Keyword arguments containing device data.
+        """
+        super().__init__(api, **kwargs)
+        LOG.debug("Setting up Climate device: %s", self.name)
 
     @property
     def current_temperature(self) -> float:
+        """
+        Gets the current temperature reported by the device.
+
+        Returns:
+            float: The current temperature.
+        """
         return cast(float, self.get_value("current_temperature", 0))
 
     @property
     def target_temperature(self) -> float:
+        """
+        Gets the target temperature set for the device.
+
+        Returns:
+            float: The target temperature.
+        """
         return cast(float, self.get_value("target_temperature", 0))
 
     @property
     def max_temp(self) -> float:
+        """
+        Gets the maximum temperature setpoint allowed for the device.
+
+        Returns:
+            float: The maximum temperature. Defaults to 36.0 if not defined.
+        """
         value = self.get_value("max_temp_setpoint", 0)
 
         if value is None or value == 0:
@@ -30,6 +61,12 @@ class Climate(HiloDevice):
 
     @property
     def min_temp(self) -> float:
+        """
+        Gets the minimum temperature setpoint allowed for the device.
+
+        Returns:
+            float: The minimum temperature. Defaults to 5.0 if not defined.
+        """
         value = self.get_value("min_temp_setpoint", 0)
 
         if value is None or value == 0:
@@ -38,11 +75,22 @@ class Climate(HiloDevice):
 
     @property
     def hvac_action(self) -> str:
+        """
+        Gets the current HVAC action of the device.
+
+        Returns:
+            str: 'heating' if heating is active, 'idle' otherwise.
+        """
         attr = self.get_value("heating", 0)
         return "heating" if attr > 0 else "idle"
 
-    async def async_set_temperature(self, **kwargs: dict[str, int]) -> None:
-        temperature = kwargs.get("temperature", 0)
-        if temperature:
-            LOG.info(f"{self._tag} Setting temperature to {temperature}")
-            await self.set_attribute("target_temperature", temperature)  # type: ignore
+    async def async_set_temperature(self, temperature: float) -> None:
+        """
+        Sets the target temperature of the device.
+
+        Args:
+            temperature: The desired target temperature.
+        """
+        if temperature != self.target_temperature:
+            LOG.info("%s Setting temperature to %s", self._tag, temperature)
+            await self.set_attribute("target_temperature", str(temperature))


### PR DESCRIPTION
This PR is fixing some lint errors to make it easier to implement #244

Error: pyhilo/device/climate.py:1:1: D400 First line should end with a period
Error: pyhilo/device/climate.py:10:7: D101 Missing docstring in public class
Error: pyhilo/device/climate.py:11:9: ANN204 Missing return type annotation for special method `__init__`
Error: pyhilo/device/climate.py:11:9: D107 Missing docstring in `__init__`
Error: pyhilo/device/climate.py:11:54: FA100 Add `from __future__ import annotations` to simplify `typing.Union`
Error: pyhilo/device/climate.py:12:42: PGH003 Use specific rule codes when ignoring type issues
Error: pyhilo/device/climate.py:16:9: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:20:9: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:24:9: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:32:9: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:40:9: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:44:15: D102 Missing docstring in public method
Error: pyhilo/device/climate.py:48:74: PGH003 Use specific rule codes when ignoring type issues