### PR TITLE
Fix multiple lint errors in oauth2helper.py

### DIFF
--- a/pyhilo/oauth2helper.py
+++ b/pyhilo/oauth2helper.py
@@ -1,16 +1,11 @@
+"""OAuth2 Helper for Hilo"""
+
 import base64
 import hashlib
 import os
 import re
-from typing import Any, cast
 
-from pyhilo.const import (
-    AUTH_AUTHORIZE,
-    AUTH_CHALLENGE_METHOD,
-    AUTH_CLIENT_ID,
-    AUTH_SCOPE,
-    AUTH_TOKEN,
-)
+from pyhilo.const import AUTH_CHALLENGE_METHOD, AUTH_CLIENT_ID, AUTH_SCOPE
 
 
 class OAuth2Helper:
@@ -30,7 +25,13 @@ class OAuth2Helper:
         code = base64.urlsafe_b64encode(sha_verifier).decode("utf-8")
         return code.replace("=", "")
 
-    def get_authorize_parameters(self):
+    def get_authorize_parameters(self) -> dict[str, str]:
+        """
+        Returns the parameters required for the authorization request.
+
+        Returns:
+            dict[str, str]: A dictionary containing the authorization parameters.
+        """
         return {
             "scope": AUTH_SCOPE,
             "code_challenge": self._code_challenge,
@@ -39,7 +40,23 @@ class OAuth2Helper:
             "client_id": AUTH_CLIENT_ID,
         }
 
-    def get_token_request_parameters(self, code, redirect_uri):
+    def get_token_request_parameters(
+        self, code: str, redirect_uri: str
+    ) -> dict[str, str]:
+        """
+        Returns the parameters required for the token request.
+
+        This method prepares the payload for the request to exchange an authorization
+        code for an access token. It includes the necessary parameters for the
+        authorization code grant type with PKCE.
+
+        Args:
+            code: The authorization code received from the authorization server.
+            redirect_uri: The redirect URI used in the authorization request.
+
+        Returns:
+            dict[str, str]: A dictionary containing the token request parameters.
+        """
         return {
             "grant_type": "authorization_code",
             "code": code,


### PR DESCRIPTION
This is fixing some of the pre-commit lint errors that are currently active:

flake8: 
pyhilo/oauth2helper.py:5:1: F401 'typing.Any' imported but unused
pyhilo/oauth2helper.py:5:1: F401 'typing.cast' imported but unused
pyhilo/oauth2helper.py:7:1: F401 'pyhilo.const.AUTH_AUTHORIZE' imported but unused
pyhilo/oauth2helper.py:7:1: F401 'pyhilo.const.AUTH_TOKEN' imported but unused

mypy:
pyhilo/oauth2helper.py:33: error: Function is missing a return type annotation  [no-untyped-def]
pyhilo/oauth2helper.py:42: error: Function is missing a type annotation  [no-untyped-def]