### PR TITLE
Remove scheduled run of lint on github

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,8 +6,6 @@ on:
       - main
       - dev
   pull_request:
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   DEFAULT_PYTHON: 3.9


### PR DESCRIPTION
It's not really helpful to run the lint on the code daily if nothing changes. It's best to just run in on push and on pull_request.

I get an email each day telling me the lint tests are failing.

This will be further more improved once #244 is ready.