### PR TITLE
Remove `homeassistant.const` dependency

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -268,3 +268,5 @@ UNMONITORED_DEVICES: Final = [
     "43094",
     "43100",
 ]
+
+STATE_UNKNOWN: Final = "unknown"

--- a/pyhilo/device/__init__.py
+++ b/pyhilo/device/__init__.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, Union, cast
 
-from homeassistant.const import STATE_UNKNOWN
-
 from pyhilo.const import (
     HILO_DEVICE_ATTRIBUTES,
     HILO_LIST_ATTRIBUTES,
@@ -16,6 +14,7 @@ from pyhilo.const import (
     JASCO_MODELS,
     JASCO_OUTLETS,
     LOG,
+    STATE_UNKNOWN,
 )
 from pyhilo.util import camel_to_snake, from_utc_timestamp
 


### PR DESCRIPTION
python-hilo should not depend on Home Assistant.

Only ./hilo/pyhilo/oauth2.py is left with Home Assistant dependency after this PR.