### PR TITLE
Fix reconnects to gql endpoint after network outage

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -7,7 +7,7 @@ import aiohttp
 LOG: Final = logging.getLogger(__package__)
 DEFAULT_STATE_FILE: Final = "hilo_state.yaml"
 REQUEST_RETRY: Final = 9
-PYHILO_VERSION: Final = "2025.5.01"
+PYHILO_VERSION: Final = "2025.6.01"
 # TODO: Find a way to keep previous line in sync with pyproject.toml automatically
 
 CONTENT_TYPE_FORM: Final = "application/x-www-form-urlencoded"

--- a/pyhilo/graphql.py
+++ b/pyhilo/graphql.py
@@ -546,7 +546,9 @@ class GraphQlHelper:
     async def subscribe_to_device_updated(
         self, location_hilo_id: str, callback: callable = None
     ) -> None:
+        LOG.debug("subscribe_to_device_updated called")
         while True:  # Loop to reconnect if the connection is lost
+            LOG.debug("subscribe_to_device_updated while true")
             access_token = await self._get_access_token()
             transport = WebsocketsTransport(
                 url=f"wss://platform.hiloenergie.com/api/digital-twin/v3/graphql?access_token={access_token}"
@@ -558,14 +560,25 @@ class GraphQlHelper:
                     async for result in session.subscribe(
                         query, variable_values={"locationHiloId": location_hilo_id}
                     ):
-                        LOG.debug(f"Received subscription result {result}")
+                        LOG.debug(
+                            f"subscribe_to_device_updated: Received subscription result {result}"
+                        )
                         device_hilo_id = self._handle_device_subscription_result(result)
                         if callback:
                             callback(device_hilo_id)
             except Exception as e:
-                LOG.debug(f"Connection lost: {e}. Reconnecting in 5 seconds...")
+                LOG.debug(
+                    f"subscribe_to_device_updated: Connection lost: {e}. Reconnecting in 5 seconds..."
+                )
                 await asyncio.sleep(5)
-                await self.call_get_location_query(location_hilo_id)
+                try:
+                    await self.call_get_location_query(location_hilo_id)
+                    LOG.debug("subscribe_to_device_updated, call_get_location_query success")
+
+                except Exception as e2:
+                    LOG.error(
+                        f"subscribe_to_device_updated, exception while reconnecting, retrying: {e2}"
+                    )
 
     async def subscribe_to_location_updated(
         self, location_hilo_id: str, callback: callable = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ exclude = ".venv/.*"
 
 [tool.poetry]
 name = "python-hilo"
-version = "2025.5.1"
+version = "2025.6.1"
 description = "A Python3, async interface to the Hilo API"
 readme = "README.md"
 authors = ["David Vallee Delisle <me@dvd.dev>"]


### PR DESCRIPTION
subscribe_to_device_updated: Wrap the calls in except in a nested try/except to make the code more robust so that we don't exit the inifinite loop.