### PR TITLE
Remove obsolete DSN identifier

### DIFF
--- a/pyhilo/api.py
+++ b/pyhilo/api.py
@@ -715,38 +715,6 @@ class API:
 
         return all_seasons
 
-    async def get_gateway(self, location_id: int) -> dict[str, Any]:
-        """Gets info about the Hilo hub (gateway)"""
-        url = self._get_url("Gateways/Info", location_id=location_id)
-        LOG.debug("Gateway URL is %s", url)
-        req = await self.async_request("get", url)
-        saved_attrs = [
-            "zigBeePairingActivated",
-            "zigBeeChannel",
-            "firmwareVersion",
-            "onlineStatus",
-            "lastStatusTime",
-            "disconnected",
-        ]
-
-        gw = {
-            "name": "Hilo Gateway",
-            "Disconnected": {"value": not req[0].get("onlineStatus") == "Online"},
-            "type": "Gateway",
-            "category": "Gateway",
-            "supportedAttributes": ", ".join(saved_attrs),
-            "settableAttributes": "",
-            "id": 1,
-            "identifier": req[0].get("dsn"),
-            "sdi": req[0].get("sdi"),
-            "provider": 1,
-            "model_number": "EQ000017",
-            "sw_version": req[0].get("firmwareVersion"),
-        }
-        for attr in saved_attrs:
-            gw[attr] = {"value": req[0].get(attr)}
-        return gw
-
     async def get_weather(self, location_id: int) -> dict[str, Any]:
         """This will return the current weather like in the app
         https://api.hiloenergie.com/Automation/v1/api/Locations/XXXX/Weather

--- a/pyhilo/devices.py
+++ b/pyhilo/devices.py
@@ -99,7 +99,7 @@ class Devices:
         return dev
 
     async def update(self) -> None:
-        """Update device list from SignalR cache + gateway from REST."""
+        """Update device list from SignalR cache."""
         # Get devices from SignalR cache (already populated by DeviceListInitialValuesReceived)
         cached_devices = self._api.get_device_cache(self.location_id)
         generated_devices = []
@@ -109,17 +109,6 @@ class Devices:
             generated_devices.append(dev)
             if dev not in self.devices:
                 self.devices.append(dev)
-
-        # Append gateway from REST API (still available)
-        try:
-            gw = await self._api.get_gateway(self.location_id)
-            LOG.debug("Generating gateway device %s", gw)
-            gw_dev = self.generate_device(gw)
-            generated_devices.append(gw_dev)
-            if gw_dev not in self.devices:
-                self.devices.append(gw_dev)
-        except Exception as err:
-            LOG.error("Failed to get gateway: %s", err)
 
         # Now add devices from external sources (e.g. unknown source tracker)
         for callback in self._api._get_device_callbacks:
@@ -183,7 +172,6 @@ class Devices:
 
         Gets location IDs from REST API, then waits for the SignalR hub
         to deliver the device list via DeviceListInitialValuesReceived.
-        The gateway is appended from REST.
         """
         LOG.info("Initialising: getting location IDs")
         location_ids = await self._api.get_location_ids()


### PR DESCRIPTION
As part of an effort to remove the now obsolete DSN identifier, we, at Hilo, noticed that the only place where it was mentionned was inside a call to a deprecated endpoint in our backend.

So, here are the changes:

- Removed the `get_gateway()` function (and doing so, removing the DSN) from `api.py`,
- Cleaned up the `devices.py`class where the aforementionned function was used,
- Updated some comments to reflect those changes.