### PR TITLE
Add TH6250WF to UNMONITORED_DEVICES

### DIFF
--- a/pyhilo/const.py
+++ b/pyhilo/const.py
@@ -283,6 +283,7 @@ UNMONITORED_DEVICES: Final = [
     "43080",
     "43094",
     "43100",
+    "TH6250WF",
 ]
 
 STATE_UNKNOWN: Final = "unknown"


### PR DESCRIPTION
Adds TH6250WF to UNMONITORED_DEVICES per #451.

This device only toggles a 24V relay and has no power-sensing
capability, so power.value is always None from Hilo's backend.
_map_power currently coerces that to 0, making sensor.<device>_power
permanently show a false 0 rather than unavailable. Confirmed via
the Hilo app that it shows no power reading for this device either.

Tested on real hardware: patched UNMONITORED_DEVICES in the installed
pyhilo package on a live Home Assistant Green instance running this
device, confirmed sensor.th6250wf_power correctly stops updating and
shows unavailable instead of 0, across two restarts, with no
regressions to the device's other sensors (temperature, hvac_action,
etc).

Closes #451
